### PR TITLE
fix[locks]: Add taxi model to no lock config in qb-vehiclekeys

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -235,6 +235,9 @@ local function spawnTaxi()
         if GetResourceState('qb-core') == "started" then
             TriggerEvent('QBCore:Notify', 'Taxi is on the way', 'success')
         end
+        if GetResourceState('qb-vehiclekeys') == "started" then
+            exports['qb-vehiclekeys']:addNoLockVehicles(Config.TaxiModel)
+        end
 
         driveTo()
         waitForTaxiDone()


### PR DESCRIPTION
Fixes #1 